### PR TITLE
feat: update rake dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
 - 2.5
 - 2.6
+- 2.7
 deploy:
   provider: rubygems
   api_key:

--- a/lib/sequel/opentracing/version.rb
+++ b/lib/sequel/opentracing/version.rb
@@ -2,6 +2,6 @@
 
 module Sequel
   module OpenTracing
-    VERSION = '0.0.4'
+    VERSION = '0.0.5'
   end
 end

--- a/sequel-opentracing.gemspec
+++ b/sequel-opentracing.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'opentracing_test_tracer', '~> 0.1'
   spec.add_development_dependency 'rubocop', '~> 0.71.0'


### PR DESCRIPTION
- fixes [rake security advisory](https://github.com/foodiefm/sequel-opentracing/network/alert/sequel-opentracing.gemspec/rake/)
- adds ruby 2.7 to be included in travis tests
- bump version to 0.0.5
